### PR TITLE
feat(context) add as simple RDF model

### DIFF
--- a/src/main/java/ch/unisg/ics/interactions/hmas/interaction/io/ArtifactProfileGraphWriter.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/interaction/io/ArtifactProfileGraphWriter.java
@@ -3,9 +3,7 @@ package ch.unisg.ics.interactions.hmas.interaction.io;
 import ch.unisg.ics.interactions.hmas.core.io.ResourceProfileGraphWriter;
 import ch.unisg.ics.interactions.hmas.interaction.signifiers.*;
 import ch.unisg.ics.interactions.hmas.interaction.vocabularies.*;
-import org.eclipse.rdf4j.model.BNode;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 
 import java.util.*;
@@ -25,15 +23,15 @@ public class ArtifactProfileGraphWriter extends ResourceProfileGraphWriter<Artif
   @Override
   public String write() {
     this.setNamespace(INTERACTION.PREFIX, INTERACTION.NAMESPACE)
-        .setNamespace(HCTL.PREFIX, HCTL.NAMESPACE)
-        .setNamespace(HTV.PREFIX, HTV.NAMESPACE)
-        .setNamespace(SHACL.PREFIX, SHACL.NAMESPACE)
-        .setNamespace(PROV.PREFIX, PROV.NAMESPACE)
-        .setNamespace(RDFS.PREFIX, RDFS.NAMESPACE)
-        .setNamespace("urn", "http://example.org/urn#")
-        .setNamespace("ex", "http://example.org/")
-        .setNamespace("xs", "http://www.w3.org/2001/XMLSchema#")
-        .addSignifiers();
+            .setNamespace(HCTL.PREFIX, HCTL.NAMESPACE)
+            .setNamespace(HTV.PREFIX, HTV.NAMESPACE)
+            .setNamespace(SHACL.PREFIX, SHACL.NAMESPACE)
+            .setNamespace(PROV.PREFIX, PROV.NAMESPACE)
+            .setNamespace(RDFS.PREFIX, RDFS.NAMESPACE)
+            .setNamespace("urn", "http://example.org/urn#")
+            .setNamespace("ex", "http://example.org/")
+            .setNamespace("xs", "http://www.w3.org/2001/XMLSchema#")
+            .addSignifiers();
 
     return super.write();
   }
@@ -87,15 +85,10 @@ public class ArtifactProfileGraphWriter extends ResourceProfileGraphWriter<Artif
         addedContexts.put(locatedContext, new HashSet<>());
       }
       graphBuilder.add(signifier, RECOMMENDS_CONTEXT, locatedContext);
-      graphBuilder.add(locatedContext, RDF.TYPE, context.getType().toIRI());
-      graphBuilder.add(locatedContext, SHACL.TARGET_CLASS, iri(context.getTargetClass()));
-      context.getInputs().stream()
-          .filter(i -> !addedContexts.get(locatedContext).contains(i))
-          .peek(i -> addedContexts.get(locatedContext).add(i))
-          .map(this::addInput)
-          .forEach(input -> {
-            graphBuilder.add(locatedContext, SHACL.PROPERTY, input);
-          });
+      Model contextModel = context.getModel();
+      for (Statement st : contextModel) {
+        graphBuilder.add(st.getSubject(), st.getPredicate(), st.getObject());
+      }
     });
   }
 
@@ -129,7 +122,7 @@ public class ArtifactProfileGraphWriter extends ResourceProfileGraphWriter<Artif
 
   private Resource addInput(Input input) {
     return input instanceof CompoundInput ? addCompoundInput((CompoundInput) input) :
-        addSimpleInput((SimpleInput) input);
+            addSimpleInput((SimpleInput) input);
   }
 
   private Resource addSimpleInput(SimpleInput input) {
@@ -176,7 +169,7 @@ public class ArtifactProfileGraphWriter extends ResourceProfileGraphWriter<Artif
 
     graphBuilder.add(iri(input.getQualifiedValueShape()), RDF.TYPE, SHACL.NODE_SHAPE);
     Optional.ofNullable(input.getClazz())
-        .ifPresent(c -> graphBuilder.add(iri(input.getQualifiedValueShape()), SHACL.CLASS, iri(c)));
+            .ifPresent(c -> graphBuilder.add(iri(input.getQualifiedValueShape()), SHACL.CLASS, iri(c)));
     input.getInputs().forEach(i -> graphBuilder.add(iri(input.getQualifiedValueShape()), SHACL.PROPERTY, addInput(i)));
 
     return inputId;

--- a/src/main/java/ch/unisg/ics/interactions/hmas/interaction/signifiers/Context.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/interaction/signifiers/Context.java
@@ -2,45 +2,43 @@ package ch.unisg.ics.interactions.hmas.interaction.signifiers;
 
 import ch.unisg.ics.interactions.hmas.core.hostables.AbstractResource;
 import ch.unisg.ics.interactions.hmas.interaction.vocabularies.SHACL;
-
-import java.util.HashSet;
-import java.util.Set;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
 
 public class Context extends AbstractResource {
-  private final String targetClass;
-  private final Set<Input> inputs;
-
-  public String getTargetClass() {
-    return this.targetClass;
-  }
-
-  public Set<Input> getInputs() {
-    return this.inputs;
-  }
+  private final Model model;
 
   protected Context(Builder builder) {
     super(SHACL.TERM.NODE_SHAPE, builder);
-    this.targetClass = builder.targetClass;
-    this.inputs = builder.inputs;
+    this.model = builder.model;
+  }
+
+  public Model getModel() {
+    return this.model;
   }
 
   public static class Builder extends AbstractBuilder<Builder, Context> {
-    protected String targetClass;
-    protected Set<Input> inputs;
+    protected Model model;
+    private final ModelBuilder modelBuilder;
 
     public Builder() {
       super(SHACL.TERM.NODE_SHAPE);
-      this.targetClass = "";
-      this.inputs = new HashSet<>();
+      this.modelBuilder = new ModelBuilder();
+      this.model = modelBuilder.build();
     }
 
-    public Builder withInput(Input input) {
-      this.inputs.add(input);
+    public Builder addStatement(Statement statement) {
+      this.modelBuilder.add(statement.getSubject(), statement.getPredicate(), statement.getObject());
+      this.model = this.modelBuilder.build();
       return this;
     }
 
-    public Builder withTargetClass(String targetClass) {
-      this.targetClass = targetClass;
+    public Builder addModel(Model model) {
+      for (Statement statement : model) {
+        addStatement(statement);
+      }
+
       return this;
     }
 

--- a/src/main/java/ch/unisg/ics/interactions/hmas/interaction/vocabularies/SHACL.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/interaction/vocabularies/SHACL.java
@@ -19,7 +19,7 @@ public class SHACL {
     public static final IRI MIN_COUNT;
     public static final IRI MAX_COUNT;
     public static final IRI OR;
-    public static final IRI HAS_VALUE;
+    public static final IRI VALUE;
     public static final IRI PATH;
     public static final IRI QUALIFIED_VALUE_SHAPE;
     public static final IRI QUALIFIED_MIN_COUNT;
@@ -46,7 +46,7 @@ public class SHACL {
         MIN_COUNT = rdf.createIRI(NAMESPACE + "minCount");
         MAX_COUNT = rdf.createIRI(NAMESPACE + "maxCount");
         OR = rdf.createIRI(NAMESPACE + "or");
-        HAS_VALUE = rdf.createIRI(NAMESPACE + "hasValue");
+        VALUE = rdf.createIRI(NAMESPACE + "value");
         PATH = rdf.createIRI(NAMESPACE + "path");
         QUALIFIED_VALUE_SHAPE = rdf.createIRI(NAMESPACE + "qualifiedValueShape");
         QUALIFIED_MIN_COUNT = rdf.createIRI(NAMESPACE + "qualifiedMinCount");
@@ -72,7 +72,7 @@ public class SHACL {
         MIN_COUNT(SHACL.MIN_COUNT),
         MAX_COUNT(SHACL.MAX_COUNT),
         OR(SHACL.OR),
-        HAS_VALUE(SHACL.HAS_VALUE),
+        VALUE(SHACL.VALUE),
         PATH(SHACL.PATH),
         QUALIFIED_VALUE_SHAPE(SHACL.QUALIFIED_VALUE_SHAPE),
         QUALIFIED_MIN_COUNT(SHACL.QUALIFIED_MIN_COUNT),

--- a/src/main/java/ch/unisg/ics/interactions/hmas/interaction/vocabularies/SHACL.java
+++ b/src/main/java/ch/unisg/ics/interactions/hmas/interaction/vocabularies/SHACL.java
@@ -19,7 +19,7 @@ public class SHACL {
     public static final IRI MIN_COUNT;
     public static final IRI MAX_COUNT;
     public static final IRI OR;
-    public static final IRI VALUE;
+    public static final IRI HAS_VALUE;
     public static final IRI PATH;
     public static final IRI QUALIFIED_VALUE_SHAPE;
     public static final IRI QUALIFIED_MIN_COUNT;
@@ -46,7 +46,7 @@ public class SHACL {
         MIN_COUNT = rdf.createIRI(NAMESPACE + "minCount");
         MAX_COUNT = rdf.createIRI(NAMESPACE + "maxCount");
         OR = rdf.createIRI(NAMESPACE + "or");
-        VALUE = rdf.createIRI(NAMESPACE + "value");
+        HAS_VALUE = rdf.createIRI(NAMESPACE + "hasValue");
         PATH = rdf.createIRI(NAMESPACE + "path");
         QUALIFIED_VALUE_SHAPE = rdf.createIRI(NAMESPACE + "qualifiedValueShape");
         QUALIFIED_MIN_COUNT = rdf.createIRI(NAMESPACE + "qualifiedMinCount");
@@ -72,7 +72,7 @@ public class SHACL {
         MIN_COUNT(SHACL.MIN_COUNT),
         MAX_COUNT(SHACL.MAX_COUNT),
         OR(SHACL.OR),
-        VALUE(SHACL.VALUE),
+        HAS_VALUE(SHACL.HAS_VALUE),
         PATH(SHACL.PATH),
         QUALIFIED_VALUE_SHAPE(SHACL.QUALIFIED_VALUE_SHAPE),
         QUALIFIED_MIN_COUNT(SHACL.QUALIFIED_MIN_COUNT),

--- a/src/test/java/ch/unisg/ics/interactions/hmas/interaction/io/ArtifactProfileGraphReaderTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/hmas/interaction/io/ArtifactProfileGraphReaderTest.java
@@ -5,16 +5,15 @@ import ch.unisg.ics.interactions.hmas.core.vocabularies.CORE;
 import ch.unisg.ics.interactions.hmas.interaction.signifiers.*;
 import ch.unisg.ics.interactions.hmas.interaction.vocabularies.HCTL;
 import ch.unisg.ics.interactions.hmas.interaction.vocabularies.SHACL;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static ch.unisg.ics.interactions.hmas.core.vocabularies.CORE.ARTIFACT;
 import static org.junit.jupiter.api.Assertions.*;
@@ -154,54 +153,54 @@ public class ArtifactProfileGraphReaderTest {
     assertEquals(2, forms.size());
 
     assertTrue(forms.stream().anyMatch(form ->
-            "https://example.org/resource".equals(form.getTarget()) && "urn:3g6lpq9v".equals(form.getIRIAsString().get()) ));
+            "https://example.org/resource".equals(form.getTarget()) && "urn:3g6lpq9v".equals(form.getIRIAsString().get())));
 
     assertTrue(forms.stream().anyMatch(form ->
-            "coaps://example.org/resource".equals(form.getTarget()) && "urn:x7aym3hn".equals(form.getIRIAsString().get()) ));
+            "coaps://example.org/resource".equals(form.getTarget()) && "urn:x7aym3hn".equals(form.getIRIAsString().get())));
   }
 
   @Test
   public void testReadArtifactProfileWithInput() {
     String expectedProfile = PREFIXES +
-        ".\n" +
-        "@prefix ex: <http://example.org/> .\n" +
-        "@prefix xs: <https://www.w3.org/2001/XMLSchema#> .\n" +
-        "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
-        "<urn:profile> a hmas:ResourceProfile ;\n" +
-        "  hmas:isProfileOf [ a hmas:Artifact ];\n" +
-        "  hmas:exposesSignifier ex:signifier .\n" +
-        "\n" +
-        "ex:signifier a hmas:Signifier ;\n" +
-        "  hmas:signifies ex:moveGripperSpecification .\n" +
-        "\n" +
-        "ex:moveGripperSpecification a sh:NodeShape;\n" +
-        "  sh:class hmas:ActionExecution ;\n" +
-        "  sh:property [\n" +
-        "    sh:path prov:used ;\n" +
-        "    sh:minCount 1;\n" +
-        "    sh:maxCount 1 ;\n" +
-        "    sh:hasValue ex:httpForm ;\n" +
-        "  ] ;\n" +
-        "  sh:property [\n" +
-        "    sh:path hmas:hasInput;\n" +
-        "    sh:qualifiedValueShape ex:gripperJointShape ;\n" +
-        "    sh:qualifiedMinCount 1 ;\n" +
-        "    sh:qualifiedMaxCount 1 \n" +
-        "  ] .\n" +
-        "\n" +
-        "ex:gripperJointShape a sh:NodeShape ;\n" +
-        "  sh:class ex:GripperJoint ;\n" +
-        "  sh:property [\n" +
-        "    sh:path ex:hasGripperValue ;\n" +
-        "    sh:minCount 1;\n" +
-        "    sh:maxCount 1 ;\n" +
-        "    sh:datatype xs:integer\n" +
-        "  ] .\n" +
-        "\n" +
-        "ex:httpForm a hctl:Form ;\n" +
-        "  hctl:hasTarget <https://api.interactions.ics.unisg.ch/leubot1/v1.3.4/gripper> ;\n" +
-        "  hctl:forContentType \"application/json\" ;\n" +
-        "  htv:methodName \"PUT\" .";
+            ".\n" +
+            "@prefix ex: <http://example.org/> .\n" +
+            "@prefix xs: <https://www.w3.org/2001/XMLSchema#> .\n" +
+            "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
+            "<urn:profile> a hmas:ResourceProfile ;\n" +
+            "  hmas:isProfileOf [ a hmas:Artifact ];\n" +
+            "  hmas:exposesSignifier ex:signifier .\n" +
+            "\n" +
+            "ex:signifier a hmas:Signifier ;\n" +
+            "  hmas:signifies ex:moveGripperSpecification .\n" +
+            "\n" +
+            "ex:moveGripperSpecification a sh:NodeShape;\n" +
+            "  sh:class hmas:ActionExecution ;\n" +
+            "  sh:property [\n" +
+            "    sh:path prov:used ;\n" +
+            "    sh:minCount 1;\n" +
+            "    sh:maxCount 1 ;\n" +
+            "    sh:hasValue ex:httpForm ;\n" +
+            "  ] ;\n" +
+            "  sh:property [\n" +
+            "    sh:path hmas:hasInput;\n" +
+            "    sh:qualifiedValueShape ex:gripperJointShape ;\n" +
+            "    sh:qualifiedMinCount 1 ;\n" +
+            "    sh:qualifiedMaxCount 1 \n" +
+            "  ] .\n" +
+            "\n" +
+            "ex:gripperJointShape a sh:NodeShape ;\n" +
+            "  sh:class ex:GripperJoint ;\n" +
+            "  sh:property [\n" +
+            "    sh:path ex:hasGripperValue ;\n" +
+            "    sh:minCount 1;\n" +
+            "    sh:maxCount 1 ;\n" +
+            "    sh:datatype xs:integer\n" +
+            "  ] .\n" +
+            "\n" +
+            "ex:httpForm a hctl:Form ;\n" +
+            "  hctl:hasTarget <https://api.interactions.ics.unisg.ch/leubot1/v1.3.4/gripper> ;\n" +
+            "  hctl:forContentType \"application/json\" ;\n" +
+            "  htv:methodName \"PUT\" .";
 
     ArtifactProfile profile = ArtifactProfileGraphReader.readFromString(expectedProfile);
 
@@ -228,8 +227,96 @@ public class ArtifactProfileGraphReaderTest {
     CompoundInput input = (CompoundInput) i.get();
     assertEquals("http://example.org/GripperJoint", input.getClazz());
     assertEquals("http://example.org/hasGripperValue",
-        ((SimpleInput) input.getInputs().stream().findFirst().get()).getPath());
+            ((SimpleInput) input.getInputs().stream().findFirst().get()).getPath());
     assertEquals("https://www.w3.org/2001/XMLSchema#integer",
-        ((SimpleInput) input.getInputs().stream().findFirst().get()).getDataType());
+            ((SimpleInput) input.getInputs().stream().findFirst().get()).getDataType());
+  }
+
+  @Test
+  public void testReadArtifactProfileWithContext() {
+    String expectedProfile = PREFIXES +
+            ".\n" +
+            "@prefix ex: <http://example.org/> .\n" +
+            "@prefix xs: <https://www.w3.org/2001/XMLSchema#> .\n" +
+            "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
+            "<urn:profile> a hmas:ResourceProfile ;\n" +
+            "  hmas:isProfileOf [ a hmas:Artifact ];\n" +
+            "  hmas:exposesSignifier ex:signifier .\n" +
+            "\n" +
+            "ex:signifier a hmas:Signifier ;\n" +
+            "  hmas:recommendsContext ex:situationShape ;\n" +
+            "  hmas:signifies ex:moveGripperSpecification .\n" +
+            "\n" +
+            "ex:moveGripperSpecification a sh:NodeShape;\n" +
+            "  sh:class hmas:ActionExecution ;\n" +
+            "  sh:property [\n" +
+            "    sh:path prov:used ;\n" +
+            "    sh:minCount 1;\n" +
+            "    sh:maxCount 1 ;\n" +
+            "    sh:hasValue ex:httpForm ;\n" +
+            "  ] .\n" +
+            "\n" +
+            "ex:situationShape a sh:NodeShape ;\n" +
+            "  sh:class hmas:ResourceProfile ;\n" +
+            "  sh:property [\n" +
+            "    sh:path hmas:isProfileOf ;\n" +
+            "    sh:qualifiedValueShape ex:agentShape ;\n" +
+            "    sh:qualifiedMinCount 1 ;\n" +
+            "    sh:qualifiedMaxCount 1 \n" +
+            "  ] .\n" +
+            "\n" +
+            "ex:agentShape a sh:NodeShape ;\n" +
+            "  sh:class hmas:Agent ;\n" +
+            "  sh:property [\n" +
+            "    sh:path ex:hasBelief ;\n" +
+            "    sh:minCount 1;\n" +
+            "    sh:maxCount 1 ;\n" +
+            "    sh:hasValue \"room(empty)\"\n" +
+            "  ] .\n" +
+            "ex:httpForm a hctl:Form ;\n" +
+            "  hctl:hasTarget <https://api.interactions.ics.unisg.ch/leubot1/v1.3.4/gripper> ;\n" +
+            "  hctl:forContentType \"application/json\" ;\n" +
+            "  htv:methodName \"PUT\" .";
+
+    ArtifactProfile profile = ArtifactProfileGraphReader.readFromString(expectedProfile);
+
+    Artifact artifact = profile.getArtifact();
+    assertEquals(ARTIFACT, artifact.getTypeAsIRI());
+
+    assertEquals(1, profile.getExposedSignifiers().size());
+    Set<Signifier> signifiers = profile.getExposedSignifiers();
+
+    List<Signifier> signifiersList = new ArrayList<>(signifiers);
+    Signifier signifier = signifiersList.get(0);
+
+    ActionSpecification actionSpec = (ActionSpecification) signifier.getResource();
+    Set<Form> forms = actionSpec.getForms();
+    assertEquals(1, forms.size());
+    Form form = new ArrayList<>(forms).get(0);
+    assertEquals("https://api.interactions.ics.unisg.ch/leubot1/v1.3.4/gripper", form.getTarget());
+    assertEquals("http://example.org/httpForm", form.getIRIAsString().get());
+
+    Set<Context> contexts = signifier.getRecommendedContexts();
+    assertEquals(1, contexts.size());
+    Context context = signifier.getRecommendedContexts().stream().findFirst().get();
+
+    Model contextModel = context.getModel();
+    SimpleValueFactory valueFactory = SimpleValueFactory.getInstance();
+    IRI hasBeliefResource = valueFactory.createIRI("http://example.org/hasBelief");
+
+    List<Resource> actualBeliefs = contextModel.filter(null, SHACL.PATH, hasBeliefResource)
+            .stream()
+            .map(Statement::getSubject)
+            .collect(Collectors.toList());
+
+    assertEquals(1, actualBeliefs.size());
+
+    List<Value> actualBeliefContents = contextModel.filter(actualBeliefs.get(0), SHACL.HAS_VALUE, null)
+            .stream()
+            .map(Statement::getObject)
+            .collect(Collectors.toList());
+
+    assertEquals(1, actualBeliefContents.size());
+    assertEquals("room(empty)", actualBeliefContents.get(0).stringValue());
   }
 }

--- a/src/test/java/ch/unisg/ics/interactions/hmas/interaction/io/ArtifactProfileGraphWriterTest.java
+++ b/src/test/java/ch/unisg/ics/interactions/hmas/interaction/io/ArtifactProfileGraphWriterTest.java
@@ -7,10 +7,16 @@ import ch.unisg.ics.interactions.hmas.interaction.vocabularies.HCTL;
 import ch.unisg.ics.interactions.hmas.interaction.vocabularies.INTERACTION;
 import ch.unisg.ics.interactions.hmas.interaction.vocabularies.PROV;
 import ch.unisg.ics.interactions.hmas.interaction.vocabularies.SHACL;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.*;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.junit.jupiter.api.Test;
@@ -45,10 +51,10 @@ public class ArtifactProfileGraphWriterTest {
 
   private static final String FORM_IRI = "<urn:3g6lpq9v>";
   private static final String SECOND_FORM_IRI = "<urn:x7aym3hn>";
-  private static String BASE_URI = "http://example.org/";
   private static final String TARGET = "https://example.org/resource";
   private static final Form BASIC_FORM = new Form.Builder(TARGET)
           .setIRIAsString(FORM_IRI).build();
+  private static String BASE_URI = "http://example.org/";
 
   private static Model readModelFromString(String profile, String baseURI)
           throws RDFParseException, RDFHandlerException, IOException {
@@ -61,6 +67,27 @@ public class ArtifactProfileGraphWriterTest {
     rdfParser.parse(stringReader, baseURI);
 
     return model;
+  }
+
+  // Compare two RDF models
+  private static void compareModels(Model modelA, Model modelB) {
+    // Iterate through the triples in modelA
+    for (Statement stmtA : modelA) {
+      // Check if the same triple exists in modelB
+      if (!modelB.contains(stmtA)) {
+        // Triple in modelA does not exist in modelB
+        System.out.println("Triple in modelA but not in modelB: " + stmtA);
+      }
+    }
+
+    // Iterate through the triples in modelB
+    for (Statement stmtB : modelB) {
+      // Check if the same triple exists in modelA
+      if (!modelA.contains(stmtB)) {
+        // Triple in modelB does not exist in modelA
+        System.out.println("Triple in modelB but not in modelA: " + stmtB);
+      }
+    }
   }
 
   @Test
@@ -250,73 +277,158 @@ public class ArtifactProfileGraphWriterTest {
   @Test
   public void testWriteArtifactProfileWithInput() throws IOException {
     String expectedProfile = PREFIXES +
-        ".\n" +
-        "@prefix ex: <http://example.org/> .\n" +
-        "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
-        "<urn:profile> a hmas:ResourceProfile ;\n" +
-        "              hmas:isProfileOf [ a hmas:Artifact ] ;\n" +
-        "              hmas:exposesSignifier ex:signifier .\n" +
-        "\n" +
-        "ex:signifier a hmas:Signifier ;\n" +
-        "             hmas:signifies ex:moveGripperSpecification .\n" +
-        "\n" +
-        "ex:moveGripperSpecification a sh:NodeShape ;\n" +
-        "         sh:class hmas:ActionExecution ;\n" +
-        "         sh:property [\n" +
-        "             sh:path prov:used ;\n" +
-        "             sh:minCount \"1\"^^xs:int;\n" +
-        "             sh:maxCount \"1\"^^xs:int ;\n" +
-        "             sh:hasValue ex:httpForm\n" +
-        "         ] ;\n" +
-        "         sh:property [\n" +
-        "             sh:path hmas:hasInput;\n" +
-        "             sh:qualifiedValueShape ex:gripperJointShape ;\n" +
-        "             sh:qualifiedMinCount \"1\"^^xs:int ;\n" +
-        "             sh:qualifiedMaxCount \"1\"^^xs:int\n" +
-        "         ] ." +
-        "\n" +
-        "ex:httpForm a hctl:Form ;\n" +
-        "  hctl:hasTarget <https://api.interactions.ics.unisg.ch/leubot1/v1.3.4/gripper> ;\n" +
-        "  hctl:forContentType \"application/json\" ;\n" +
-        "  htv:methodName \"PUT\" ." +
-        "\n" +
-        "ex:gripperJointShape a sh:NodeShape ;\n" +
-        "  sh:class ex:GripperJoint ;\n" +
-        "  sh:property [\n" +
-        "    sh:path ex:hasGripperValue ;\n" +
-        "    sh:minCount \"1\"^^xs:int;\n" +
-        "    sh:maxCount \"1\"^^xs:int;\n" +
-        "    sh:datatype xs:integer\n" +
-        "  ] .\n";
+            ".\n" +
+            "@prefix ex: <http://example.org/> .\n" +
+            "@prefix htv: <http://www.w3.org/2011/http#> .\n" +
+            "<urn:profile> a hmas:ResourceProfile ;\n" +
+            "              hmas:isProfileOf [ a hmas:Artifact ] ;\n" +
+            "              hmas:exposesSignifier ex:signifier .\n" +
+            "\n" +
+            "ex:signifier a hmas:Signifier ;\n" +
+            "             hmas:signifies ex:moveGripperSpecification .\n" +
+            "\n" +
+            "ex:moveGripperSpecification a sh:NodeShape ;\n" +
+            "         sh:class hmas:ActionExecution ;\n" +
+            "         sh:property [\n" +
+            "             sh:path prov:used ;\n" +
+            "             sh:minCount \"1\"^^xs:int;\n" +
+            "             sh:maxCount \"1\"^^xs:int ;\n" +
+            "             sh:hasValue ex:httpForm\n" +
+            "         ] ;\n" +
+            "         sh:property [\n" +
+            "             sh:path hmas:hasInput;\n" +
+            "             sh:qualifiedValueShape ex:gripperJointShape ;\n" +
+            "             sh:qualifiedMinCount \"1\"^^xs:int ;\n" +
+            "             sh:qualifiedMaxCount \"1\"^^xs:int\n" +
+            "         ] ." +
+            "\n" +
+            "ex:httpForm a hctl:Form ;\n" +
+            "  hctl:hasTarget <https://api.interactions.ics.unisg.ch/leubot1/v1.3.4/gripper> ;\n" +
+            "  hctl:forContentType \"application/json\" ;\n" +
+            "  htv:methodName \"PUT\" ." +
+            "\n" +
+            "ex:gripperJointShape a sh:NodeShape ;\n" +
+            "  sh:class ex:GripperJoint ;\n" +
+            "  sh:property [\n" +
+            "    sh:path ex:hasGripperValue ;\n" +
+            "    sh:minCount \"1\"^^xs:int;\n" +
+            "    sh:maxCount \"1\"^^xs:int;\n" +
+            "    sh:datatype xs:integer\n" +
+            "  ] .\n";
 
     Form httpForm = new Form.Builder("https://api.interactions.ics.unisg.ch/leubot1/v1.3.4/gripper")
-        .setMethodName("PUT")
-        .setContentType("application/json")
-        .setIRIAsString("http://example.org/httpForm")
-        .build();
+            .setMethodName("PUT")
+            .setContentType("application/json")
+            .setIRIAsString("http://example.org/httpForm")
+            .build();
 
     Input gripperJointInput = new CompoundInput.Builder()
-        .withClazz("http://example.org/GripperJoint")
-        .withQualifiedValueShape("http://example.org/gripperJointShape")
-        .withInput(new SimpleInput.Builder("http://example.org/hasGripperValue")
-            .withDataType("http://www.w3.org/2001/XMLSchema#integer")
-            .build())
-        .build();
+            .withClazz("http://example.org/GripperJoint")
+            .withQualifiedValueShape("http://example.org/gripperJointShape")
+            .withInput(new SimpleInput.Builder("http://example.org/hasGripperValue")
+                    .withDataType("http://www.w3.org/2001/XMLSchema#integer")
+                    .build())
+            .build();
 
     ActionSpecification moveGripperSpec = new ActionSpecification.Builder(httpForm)
-        .withInput(gripperJointInput)
-        .setIRIAsString("http://example.org/moveGripperSpecification")
-        .build();
+            .withInput(gripperJointInput)
+            .setIRIAsString("http://example.org/moveGripperSpecification")
+            .build();
 
     ArtifactProfile profile =
-        new ArtifactProfile.Builder(new Artifact.Builder().build())
-            .setIRIAsString("urn:profile")
-            .exposeSignifier(
-                new Signifier.Builder(moveGripperSpec)
-                    .setIRIAsString("http://example.org/signifier")
-                    .build()
-            )
-            .build();
+            new ArtifactProfile.Builder(new Artifact.Builder().build())
+                    .setIRIAsString("urn:profile")
+                    .exposeSignifier(
+                            new Signifier.Builder(moveGripperSpec)
+                                    .setIRIAsString("http://example.org/signifier")
+                                    .build()
+                    )
+                    .build();
+
+    assertIsomorphicGraphs(expectedProfile, profile);
+  }
+
+  @Test
+  public void testWriteArtifactProfileWithContext() throws IOException {
+    String expectedProfile = PREFIXES +
+            ".\n" +
+            "@prefix ex: <http://example.org/> .\n" +
+            "<urn:profile> a hmas:ResourceProfile ;\n" +
+            " hmas:isProfileOf [ a hmas:Artifact ];\n" +
+            " hmas:exposesSignifier [ a hmas:Signifier ;\n" +
+            "    hmas:recommendsContext ex:situationShape ;\n" +
+            "    hmas:signifies [ a sh:NodeShape ;\n" +
+            "       sh:class hmas:ActionExecution ;\n" +
+            "       sh:property [\n" +
+            "          sh:path prov:used ;\n" +
+            "          sh:minCount \"1\"^^xs:int;\n" +
+            "          sh:maxCount \"1\"^^xs:int;\n" +
+            "          sh:hasValue " + FORM_IRI + " ;\n" +
+            "      ]\n" +
+            "   ]\n" +
+            "] .\n" +
+            FORM_IRI + " a hctl:Form ;\n" + //here the URN is randomly generated
+            "  hctl:forContentType \"application/json\" ;\n" +
+            "  hctl:hasTarget <https://example.org/resource> . \n" +
+            "\n" +
+            "ex:situationShape a sh:NodeShape ;\n" +
+            "  sh:class hmas:ResourceProfile ;\n" +
+            "  sh:property [\n" +
+            "    sh:path hmas:isProfileOf ;\n" +
+            "    sh:qualifiedValueShape ex:agentShape ;\n" +
+            "    sh:qualifiedMinCount \"1\"^^xs:int;\n" +
+            "    sh:qualifiedMaxCount \"1\"^^xs:int;\n" +
+            "  ] .\n" +
+            "\n" +
+            "ex:agentShape a sh:NodeShape ;\n" +
+            "  sh:class hmas:Agent ;\n" +
+            "  sh:property [\n" +
+            "    sh:path prs:hasBelief ;\n" +
+            "    sh:minCount \"1\"^^xs:int;\n" +
+            "    sh:maxCount \"1\"^^xs:int;\n" +
+            "    sh:hasValue \"room(empty)\"\n" +
+            "  ] .";
+
+    ActionSpecification actionSpec = new ActionSpecification.Builder(BASIC_FORM).build();
+
+    SimpleValueFactory rdfFactory = SimpleValueFactory.getInstance();
+    IRI situationShapeIRI = rdfFactory.createIRI("http://example.org/situationShape");
+    IRI agentShapeIRI = rdfFactory.createIRI("http://example.org/agentShape");
+    IRI beliefPropIRI = rdfFactory.createIRI("http://example.org/prs#hasBelief");
+    BNode profileProperty = Values.bnode();
+    BNode agentProperty = Values.bnode();
+
+    ModelBuilder contextModelBuilder = new ModelBuilder()
+            .subject(situationShapeIRI)
+            .add(RDF.TYPE, SHACL.NODE_SHAPE)
+            .add(SHACL.CLASS, CORE.RESOURCE_PROFILE)
+            .add(SHACL.PROPERTY, profileProperty)
+            .subject(profileProperty)
+            .add(SHACL.PATH, CORE.IS_PROFILE_OF)
+            .add(SHACL.QUALIFIED_MIN_COUNT, 1)
+            .add(SHACL.QUALIFIED_MAX_COUNT, 1)
+            .add(SHACL.QUALIFIED_VALUE_SHAPE, agentShapeIRI)
+            .subject(agentShapeIRI)
+            .add(RDF.TYPE, SHACL.NODE_SHAPE)
+            .add(SHACL.CLASS, CORE.AGENT)
+            .add(SHACL.PROPERTY, agentProperty)
+            .subject(agentProperty)
+            .add(SHACL.PATH, beliefPropIRI)
+            .add(SHACL.MIN_COUNT, 1)
+            .add(SHACL.MAX_COUNT, 1)
+            .add(SHACL.HAS_VALUE, "room(empty)");
+
+    Context context = new Context.Builder()
+            .setIRIAsString("http://example.org/situationShape")
+            .addModel(contextModelBuilder.build()).build();
+
+    ArtifactProfile profile =
+            new ArtifactProfile.Builder(new Artifact.Builder().build())
+                    .setIRIAsString("urn:profile")
+                    .exposeSignifier(new Signifier.Builder(actionSpec)
+                            .addRecommendedContext(context)
+                            .build())
+                    .build();
 
     assertIsomorphicGraphs(expectedProfile, profile);
   }
@@ -326,7 +438,7 @@ public class ArtifactProfileGraphWriterTest {
     String baseUri = BASE_URI;
     BASE_URI = "http://example.org/ontology-example";
     URL fileResource = ArtifactProfileGraphReaderTest.class.getClassLoader()
-        .getResource("artifact-profile.ttl");
+            .getResource("artifact-profile.ttl");
     String profilePath = Paths.get(fileResource.toURI()).toFile().getPath();
     ArtifactProfile profile = ArtifactProfileGraphReader.readFromFile(profilePath);
     assertIsomorphicGraphs(Files.readString(Paths.get(profilePath)), profile);
@@ -348,6 +460,7 @@ public class ArtifactProfileGraphWriterTest {
     LOGGER.info("Actual:\n" + actualProfile);
 
     Model actualModel = readModelFromString(actualProfile, BASE_URI);
+    compareModels(expectedModel, actualModel);
 
     assertTrue(Models.isomorphic(expectedModel, actualModel));
   }


### PR DESCRIPTION
Reads and writes recommended context of signifiers as a simple RDF model. 

Addresses the context feature based on the 2nd option for https://github.com/danaivach/hmas-java/issues/8 